### PR TITLE
Changed split to regex

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -43,7 +43,7 @@ end
 
 def getFunctions(code)
 	functions = []
-	words = code.split(" ")
+	words = code.split(/(?<!,) /)
 	words.length.times do |i|
 		if words[i] == "def"
 			functions << words[i + 1]

--- a/main.rb
+++ b/main.rb
@@ -46,7 +46,7 @@ def getFunctions(code)
 	words = code.split(/(?<!,) /)
 	words.length.times do |i|
 		if words[i] == "def"
-			functions << words[i + 1]
+			functions << words[i + 1].strip
 		end
 	end
 	return functions

--- a/main.rb
+++ b/main.rb
@@ -43,7 +43,7 @@ end
 
 def getFunctions(code)
 	functions = []
-	words = code.split(/(?<!,) /)
+	words = code.split(/(?<!,)\s/)
 	words.length.times do |i|
 		if words[i] == "def"
 			functions << words[i + 1].strip


### PR DESCRIPTION
The splitter was matching the ", ", in the function definition, as the end of the function name. Fixed this by using a negative lookbehind regular expression.

---

This made it look like the end bracket was being replaced with a comma - hence the branch name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stellardoor5319/docilater/13)
<!-- Reviewable:end -->
