### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/stellardoor5319/docilater/badge.svg)](https://snyk.io/test/github/stellardoor5319/docilater)
 [![Coverage Status](https://coveralls.io/repos/github/StellarDoor5319/docilater/badge.svg?branch=master)](https://coveralls.io/github/StellarDoor5319/docilater?branch=master)
 [![Inline docs](http://inch-ci.org/github/StellarDoor5319/docilater.svg?branch=master)](http://inch-ci.org/github/StellarDoor5319/docilater)
+[![Help Contribute to Open Source](https://www.codetriage.com/stellardoor5319/docilater/badges/users.svg)](https://www.codetriage.com/stellardoor5319/docilater)
 
 [![Github All Releases (Downloads)](https://img.shields.io/github/downloads/StellarDoor5319/docilater/total.svg?label=GitHub%20downloads)](https://github.com/StellarDoor5319/docilater/releases)
 ![GitHub contributors](https://img.shields.io/github/contributors/StellarDoor5319/docilater.svg)


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stellardoor5319/docilater/63)
<!-- Reviewable:end -->
